### PR TITLE
Adding Italy and Spain to messages

### DIFF
--- a/modules/ppcp-button/src/Helper/MessagesApply.php
+++ b/modules/ppcp-button/src/Helper/MessagesApply.php
@@ -26,6 +26,8 @@ class MessagesApply {
 		'GB',
 		'FR',
 		'AU',
+		'IT',
+		'ES',
 	);
 
 	/**


### PR DESCRIPTION
Messaging and buttons will be available in late March.



### Description

Add Italy and Spain to Pay Later messaging list.

### Steps to Test

1. Change store country to Spain or Italy.
2. Go to Settings
3. Verify Pay Later messaging options appear in admin.
4. Input a IT or ES client ID.
5. Set currency to EUR
6. Go to a page where messaging should be displayed.

### Documentation

Any documentation pages that list geographic regions for Pay Later messaging will need to add Italy and Spain.

### Changelog Entry

Added Pay Later messaging options for Italy and Spain.
